### PR TITLE
Add GitHub issue templates and security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,125 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior in vibexp
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Bug Report
+        
+        Thank you for taking the time to report a bug! Please provide as much detail as possible to help us reproduce and fix the issue.
+  
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: Please confirm the following
+      options:
+        - label: I have searched existing issues to avoid duplicates
+          required: true
+        - label: I am running the latest version or have specified my version below
+          required: true
+  
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is
+      placeholder: Describe what happened
+    validations:
+      required: true
+  
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: How can we reproduce this bug?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+  
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: Describe what you expected to happen
+    validations:
+      required: true
+  
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: Describe what actually happened instead
+    validations:
+      required: true
+  
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which component is affected?
+      options:
+        - Frontend/UI
+        - Backend API
+        - Database
+        - Authentication
+        - MCP Integration
+        - Agent System
+        - Other
+    validations:
+      required: true
+  
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Details
+      description: Provide information about your environment
+      placeholder: |
+        - OS: [e.g. Windows 11, macOS 14, Ubuntu 22.04]
+        - Browser (if applicable): [e.g. Chrome 120, Firefox 121]
+        - vibexp version: [e.g. v1.2.3 or commit hash]
+        - Backend API version (if known): [e.g. v0.5.0]
+      render: markdown
+    validations:
+      required: true
+  
+  - type: textarea
+    id: error-logs
+    attributes:
+      label: Error Logs / Screenshots
+      description: If applicable, add error logs, console output, or screenshots
+      placeholder: Paste error messages or drag and drop screenshots here
+      render: shell
+    validations:
+      required: false
+  
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem
+      placeholder: Any additional information that might be helpful (network conditions, specific data, etc.)
+    validations:
+      required: false
+  
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this bug?
+      options:
+        - Critical - System is unusable
+        - High - Major functionality broken
+        - Medium - Feature partially working
+        - Low - Minor issue or cosmetic
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📚 Documentation
+    url: https://github.com/shaharia-lab/vibexp/blob/main/README.md
+    about: Read the project documentation and user guide
+  - name: 🤝 Contributing Guide
+    url: https://github.com/shaharia-lab/vibexp/blob/main/CONTRIBUTING.md
+    about: Learn how to contribute to vibexp
+  - name: 🔒 Security Policy
+    url: https://github.com/shaharia-lab/vibexp/security/policy
+    about: Report security vulnerabilities responsibly
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,99 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement for vibexp
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Feature Request
+        
+        Thank you for taking the time to suggest a new feature! Please provide as much detail as possible to help us understand your request.
+  
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: Please confirm the following
+      options:
+        - label: I have searched existing issues and discussions to avoid duplicates
+          required: true
+        - label: This feature request is specific and actionable
+          required: true
+  
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? What need does it address?
+      placeholder: "I'm always frustrated when... / It would be helpful if..."
+    validations:
+      required: true
+  
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see implemented
+      placeholder: Provide a clear and detailed description of what you want to happen
+    validations:
+      required: true
+  
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or workarounds?
+      placeholder: Describe alternatives you've considered
+    validations:
+      required: false
+  
+  - type: dropdown
+    id: feature-type
+    attributes:
+      label: Feature Type
+      description: What type of feature is this?
+      options:
+        - New functionality
+        - Enhancement to existing feature
+        - UI/UX improvement
+        - Performance improvement
+        - Developer experience
+        - Documentation
+        - Other
+    validations:
+      required: true
+  
+  - type: checkboxes
+    id: impact-areas
+    attributes:
+      label: Impact Areas
+      description: Which areas of the project would this feature affect?
+      options:
+        - label: Requires backend API changes
+        - label: Requires frontend changes
+        - label: Requires database schema changes
+        - label: Requires documentation updates
+        - label: Contains breaking changes
+        - label: Requires new dependencies
+  
+  - type: textarea
+    id: use-cases
+    attributes:
+      label: Use Cases
+      description: Describe specific use cases or scenarios where this feature would be valuable
+      placeholder: |
+        1. Use case one...
+        2. Use case two...
+    validations:
+      required: false
+  
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, or screenshots about the feature request
+      placeholder: Any additional information that might be helpful (diagrams, mockups, examples from other tools)
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,0 +1,84 @@
+name: 💬 General Issue
+description: For questions, discussions, or issues that don't fit other categories
+title: "[General]: "
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## General Issue / Question
+        
+        Use this template for:
+        - Questions about using vibexp
+        - General discussions
+        - Suggestions that don't fit feature requests
+        - Other topics that don't fit the specific templates
+  
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: Please confirm the following
+      options:
+        - label: I have searched existing issues and discussions
+          required: true
+        - label: This doesn't fit other issue templates (bug, feature, security)
+          required: true
+  
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      description: What type of issue is this?
+      options:
+        - Question
+        - Discussion
+        - Documentation
+        - Configuration/Setup
+        - Integration
+        - Other
+    validations:
+      required: true
+  
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear and detailed description
+      placeholder: Describe your question, suggestion, or topic
+    validations:
+      required: true
+  
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / Background
+      description: Provide any relevant context or background information
+      placeholder: |
+        - What are you trying to achieve?
+        - What have you tried so far?
+        - Any relevant setup or configuration details
+    validations:
+      required: false
+  
+  - type: textarea
+    id: relevant-links
+    attributes:
+      label: Relevant Links / References
+      description: Add any relevant links, documentation, or references
+      placeholder: |
+        - Documentation: ...
+        - Related issues: ...
+        - External resources: ...
+    validations:
+      required: false
+  
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: Any other information that might be helpful
+      placeholder: Add any other context, screenshots, or details
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -1,0 +1,92 @@
+name: 🔒 Security Vulnerability Report
+description: Report a security vulnerability (Please do not disclose sensitive details publicly)
+title: "[Security]: "
+labels: ["security", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## ⚠️ Security Notice
+        
+        **IMPORTANT:** If you believe you've found a critical security vulnerability, please follow our [responsible disclosure process](../SECURITY.md) instead of creating a public issue.
+        
+        For non-critical security concerns or questions, you may use this template.
+        
+  - type: checkboxes
+    id: acknowledgment
+    attributes:
+      label: Security Acknowledgment
+      description: Please confirm you understand the security guidelines
+      options:
+        - label: I have read the security guidelines and this is not a critical vulnerability
+          required: true
+        - label: I have searched existing issues to avoid duplicates
+          required: true
+  
+  - type: textarea
+    id: vulnerability-description
+    attributes:
+      label: Vulnerability Description
+      description: Provide a clear and concise description of the security concern
+      placeholder: Describe the security issue or concern
+    validations:
+      required: true
+  
+  - type: dropdown
+    id: affected-versions
+    attributes:
+      label: Affected Versions
+      description: Which versions are affected?
+      multiple: true
+      options:
+        - Latest release
+        - Specific version (specify in additional context)
+        - Development/main branch
+        - Unknown
+    validations:
+      required: true
+  
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps To Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Step one
+        2. Step two
+        3. ...
+    validations:
+      required: true
+  
+  - type: dropdown
+    id: impact-assessment
+    attributes:
+      label: Impact Assessment
+      description: What is the potential impact of this vulnerability?
+      options:
+        - Low - Minimal impact
+        - Medium - Moderate impact
+        - High - Significant impact
+        - Critical - Severe impact
+        - Unknown
+    validations:
+      required: true
+  
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution (Optional)
+      description: If you have suggestions for fixing this issue, please share them
+      placeholder: Describe potential solutions or mitigations
+    validations:
+      required: false
+  
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or logs about the security concern
+      placeholder: Any additional information that might be helpful
+    validations:
+      required: false
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,104 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of vibexp seriously. If you have discovered a security vulnerability, we appreciate your help in disclosing it to us in a responsible manner.
+
+### How to Report a Security Vulnerability
+
+**Please DO NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via one of the following methods:
+
+1. **Email**: Send details to [mail@shaharia.com](mailto:mail@shaharia.com) with the subject line "Security Vulnerability Report - vibexp"
+2. **GitHub Security Advisory**: Use GitHub's [private security vulnerability reporting](https://github.com/shaharia-lab/vibexp/security/advisories/new)
+
+### What to Include in Your Report
+
+Please include as much of the following information as possible:
+
+- Type of vulnerability (e.g., XSS, SQL injection, authentication bypass, etc.)
+- Full paths of source file(s) related to the vulnerability
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the vulnerability, including how an attacker might exploit it
+- Any suggested remediation steps
+
+### What to Expect
+
+- **Response Time**: We will acknowledge receipt of your vulnerability report within 48 hours
+- **Communication**: We will keep you informed about the progress of fixing the vulnerability
+- **Credit**: We will credit you in the security advisory (unless you prefer to remain anonymous)
+- **Timeline**: We aim to release fixes for confirmed vulnerabilities within 90 days
+
+### Scope
+
+This security policy applies to:
+
+- vibexp backend API
+- vibexp frontend application
+- vibexp MCP server implementations
+- All official vibexp repositories under the shaharia-lab organization
+
+### Out of Scope
+
+The following are generally **not** considered security vulnerabilities:
+
+- Vulnerabilities in third-party dependencies (please report to the respective maintainers)
+- Social engineering attacks
+- Denial of Service (DoS) attacks requiring significant resources
+- Issues in unsupported or deprecated versions
+- Attacks requiring physical access to a user's device
+
+### Safe Harbor
+
+We consider security research conducted under this policy to be:
+
+- Authorized concerning any applicable anti-hacking laws
+- Exempt from DMCA
+- Lawful and helpful to the overall security of the Internet
+
+As long as you:
+
+- Make a good faith effort to avoid privacy violations, data destruction, and service interruption
+- Only interact with accounts you own or with explicit permission from the account holder
+- Do not exploit vulnerabilities beyond the minimum necessary to confirm their existence
+- Do not access or modify data beyond what is necessary to demonstrate the vulnerability
+
+## Supported Versions
+
+We currently support the following versions with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| main    | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Security Best Practices
+
+When using vibexp, we recommend:
+
+- Keep your installation up to date with the latest releases
+- Use strong, unique API keys and rotate them regularly
+- Enable HTTPS/TLS for all network communications
+- Follow the principle of least privilege for user permissions
+- Regularly review access logs and audit trails
+- Keep dependencies up to date
+
+## Security Updates
+
+Security updates will be announced via:
+
+- GitHub Security Advisories
+- Release notes in the repository
+- Git tags for security releases
+
+## Questions?
+
+If you have questions about this security policy, please open a [general issue](https://github.com/shaharia-lab/vibexp/issues/new/choose) or email [mail@shaharia.com](mailto:mail@shaharia.com).
+
+---
+
+Thank you for helping keep vibexp and our community safe!
+


### PR DESCRIPTION
## Overview

This PR implements standardized GitHub issue templates and a security policy for the vibexp repository.

## Changes

- ✅ Created 4 issue templates in YAML format:
  - **Security Vulnerability Report**: For reporting security issues with responsible disclosure guidelines
  - **Feature Request**: For suggesting new features and enhancements
  - **Bug Report**: For reporting bugs with detailed reproduction steps
  - **General Issue**: For questions, discussions, and other topics

- ✅ Created  to disable blank issues and add helpful links to documentation
- ✅ Created  with responsible vulnerability disclosure process

## Features

- All templates use GitHub's YAML format for better structure and validation
- Includes appropriate required/optional fields for each template type
- Automatic label assignment (security, enhancement, bug, needs-triage)
- Mobile-friendly with clear, concise labels
- Checkboxes for prerequisites and acknowledgments
- Dropdown menus for categorization

## Testing

- All templates follow GitHub's official schema
- Files are properly structured and ready for use in the GitHub UI

## Related

- Closes DL-233